### PR TITLE
initialize the resources list inside the cluster loop

### DIFF
--- a/main.go
+++ b/main.go
@@ -20,7 +20,6 @@ var (
 	projectID = flag.String("project", "", "Enter the Project ID")
 	zone      = flag.String("zone", "-", "Enter the Compute zone")
 	resource  = flag.String("resource", "", "Enter the resource type")
-	resources []string
 	ns        string
 )
 
@@ -88,6 +87,8 @@ func listResources(svc *container.Service, projectID, zone, rs string) string {
 		if err != nil {
 			return rs
 		}
+
+		var resources []string
 
 		switch rs {
 		case "policysecurity":


### PR DESCRIPTION
This commit moves the resources list initialization inside the cluster
loop. This is required to start with an empty list for each cluster
instead of a list already filed with the resources of the previous cluster.

Fix a bug where each cluster is listing resources that are only existing
in the cluster previously listed.
